### PR TITLE
Eliminate client version check

### DIFF
--- a/src/rabbit_jms_topic_exchange.erl
+++ b/src/rabbit_jms_topic_exchange.erl
@@ -113,8 +113,7 @@ route( #exchange{name = XName}
 validate(_X) -> ok.
 
 % After exchange declaration and recovery
-create(transaction, #exchange{name = XName, arguments = XArgs}) ->
-  check_version_arg(XName, XArgs),
+create(transaction, #exchange{name = XName}) ->
   add_initial_record(XName);
 create(_Tx, _X) ->
   ok.
@@ -134,7 +133,6 @@ add_binding( Tx
            , #exchange{name = XName}
            , #binding{key = BindingKey, destination = Dest, args = Args}
            ) ->
-  check_version_arg(XName, Args),
   Selector = get_string_arg(Args, ?RJMS_COMPILED_SELECTOR_ARG),
   BindGen = generate_binding_fun(Selector),
   case {Tx, BindGen} of
@@ -166,14 +164,6 @@ policy_changed(_X1, _X2) -> ok.
 
 %%----------------------------------------------------------------------------
 %% P R I V A T E   F U N C T I O N S
-
-% Check version argument, if supplied
-check_version_arg(XName, Args) ->
-  Version = get_string_arg(Args, ?RJMS_VERSION_ARG, "pre-1.2.0"),
-  case lists:member(Version, ?RJMS_COMPATIBLE_VERSIONS) of
-    true  -> ok;
-    false -> client_version_error(XName, Version)
-  end.
 
 % Get a string argument from the args or arguments parameters
 get_string_arg(Args, ArgName) -> get_string_arg(Args, ArgName, error).
@@ -301,12 +291,6 @@ exchange_state_corrupt_error(#resource{name = XName}) ->
   rabbit_misc:protocol_error( internal_error
                             , "exchange named '~s' has no saved state or incorrect saved state"
                             , [XName] ).
-
-% version error
-client_version_error(#resource{name = XName}, Version) ->
-  rabbit_misc:protocol_error( internal_error
-                            , "client version '~s' incompatible with plugin for operation on exchange named '~s'"
-                            , [Version, XName] ).
 
 % parsing error
 parsing_error(#resource{name = XName}, S, #resource{name = DestName}) ->

--- a/test/rjms_topic_selector_SUITE.erl
+++ b/test/rjms_topic_selector_SUITE.erl
@@ -28,7 +28,6 @@
 %% Useful test constructors
 -define(BSELECTARG(BinStr), {?RJMS_COMPILED_SELECTOR_ARG, longstr, BinStr}).
 -define(BASICMSG(Payload, Hdrs), #'amqp_msg'{props=#'P_basic'{headers=Hdrs}, payload=Payload}).
--define(VERSION_ARG, {?RJMS_VERSION_ARG, longstr, <<"1.4.7">>}).
 
 all() ->
     [
@@ -81,11 +80,11 @@ test_topic_selection(Config) ->
     {Connection, Channel} = open_connection_and_channel(Config),
     #'confirm.select_ok'{} = amqp_channel:call(Channel, #'confirm.select'{}),
 
-    Exchange = declare_rjms_exchange(Channel, "rjms_test_topic_selector_exchange", [?VERSION_ARG]),
+    Exchange = declare_rjms_exchange(Channel, "rjms_test_topic_selector_exchange", []),
 
     %% Declare a queue and bind it
     Q = declare_queue(Channel),
-    bind_queue(Channel, Q, Exchange, <<"select-key">>, [?BSELECTARG(<<"{ident, <<\"boolVal\">>}.">>), ?VERSION_ARG]),
+    bind_queue(Channel, Q, Exchange, <<"select-key">>, [?BSELECTARG(<<"{ident, <<\"boolVal\">>}.">>)]),
 
     publish_two_messages(Channel, Exchange, <<"select-key">>),
     amqp_channel:wait_for_confirms(Channel, 5000),
@@ -99,11 +98,11 @@ test_default_topic_selection(Config) ->
     {Connection, Channel} = open_connection_and_channel(Config),
     #'confirm.select_ok'{} = amqp_channel:call(Channel, #'confirm.select'{}),
 
-    Exchange = declare_rjms_exchange(Channel, "rjms_test_default_selector_exchange", [?VERSION_ARG]),
+    Exchange = declare_rjms_exchange(Channel, "rjms_test_default_selector_exchange", []),
 
     %% Declare a queue and bind it
     Q = declare_queue(Channel),
-    bind_queue(Channel, Q, Exchange, <<"select-key">>, [?BSELECTARG(<<"{ident, <<\"boolVal\">>}.">>), ?VERSION_ARG]),
+    bind_queue(Channel, Q, Exchange, <<"select-key">>, [?BSELECTARG(<<"{ident, <<\"boolVal\">>}.">>)]),
     publish_two_messages(Channel, Exchange, <<"select-key">>),
     amqp_channel:wait_for_confirms(Channel, 5000),
 


### PR DESCRIPTION
It made sense when the JMS topic exchange and Java client were
released and versioned in lock step but not anymore. Plus it currently
fails declarations over HTTP API.

Fixes #9.