### PR TITLE
wait_for_confirms timeout is in seconds

### DIFF
--- a/test/rjms_topic_selector_SUITE.erl
+++ b/test/rjms_topic_selector_SUITE.erl
@@ -77,7 +77,7 @@ test_topic_selection(Config) ->
     bind_queue(Channel, Q, Exchange, <<"select-key">>, [?BSELECTARG(<<"{ident, <<\"boolVal\">>}.">>)]),
 
     publish_two_messages(Channel, Exchange, <<"select-key">>),
-    amqp_channel:wait_for_confirms(Channel, 5000),
+    amqp_channel:wait_for_confirms(Channel, 5),
 
     get_and_check(Channel, Q, 0, <<"true">>),
 


### PR DESCRIPTION
References rabbitmq/rabbitmq-erlang-client#138

cc @dumbbell